### PR TITLE
Basic tuner functionality

### DIFF
--- a/scenes/tuner.gd
+++ b/scenes/tuner.gd
@@ -1,0 +1,70 @@
+extends Control
+
+
+enum TuningMode {
+	CHROMATIC,
+	GUITAR,
+	PHIN,
+}
+
+@export var tuning_mode: TuningMode
+@export var max_needle_angle = 70.0
+
+@onready var needle = $%"Needle"
+
+
+func _process(delta):
+	var sin_value = 8 * (sin(0.0001 * Time.get_ticks_msec()) + 1) * 0.5
+	var frequency = 27.5 * pow(2, sin_value)
+	set_input_frequency(frequency)
+
+
+func set_input_frequency(new_frequency: float):
+	var nearest_frequency_data = _get_nearest_target_frequency(new_frequency)
+	$Label.text = nearest_frequency_data.note_name
+	
+	var target: float = nearest_frequency_data.frequency
+	var min_frequency: float = 0.5 * target * pow(2.0, 11.5/12.0)
+	var max_frequency: float = target * pow(2, 0.5/12.0)
+	
+	var deviation = inverse_lerp(min_frequency, max_frequency, new_frequency)
+	deviation = clamp(deviation, 0.0, 1.0)
+	
+	needle.rotation = deg_to_rad(lerp(-max_needle_angle, max_needle_angle, deviation))
+
+
+func _get_nearest_target_frequency(frequency: float):
+	var frequencies: Array
+	var note_names: Array
+	
+	match tuning_mode:
+		TuningMode.CHROMATIC:
+			frequencies = NoteFrequency.CHROMATIC.duplicate()
+			note_names = NoteFrequency.CHROMATIC_NAMES.duplicate()
+		TuningMode.GUITAR:
+			frequencies = [
+				NoteFrequency.E2,
+				NoteFrequency.A2,
+				NoteFrequency.D3,
+				NoteFrequency.G3,
+				NoteFrequency.B3,
+				NoteFrequency.E4
+				]
+			note_names = ["E2", "A2", "D3", "G3", "B3", "E4"]
+		TuningMode.PHIN:
+			frequencies = [
+				NoteFrequency.E3,
+				NoteFrequency.A3,
+				NoteFrequency.E4
+			]
+			note_names = ["E3", "A3", "E4"]
+	
+	var target_index: int = 0
+	for i in frequencies.size():
+		if abs(frequencies[i] - frequency) < abs(frequencies[target_index] - frequency):
+			target_index = i
+	
+	return {
+		frequency = frequencies[target_index],
+		note_name = note_names[target_index]
+	}

--- a/scenes/tuner.tscn
+++ b/scenes/tuner.tscn
@@ -1,0 +1,79 @@
+[gd_scene load_steps=6 format=3 uid="uid://c0psdyqkp43ov"]
+
+[ext_resource type="Texture2D" uid="uid://1uht5wqqvkkv" path="res://assets/gui/icons/up.png" id="1_gdowb"]
+[ext_resource type="Script" path="res://scenes/tuner.gd" id="1_nftna"]
+[ext_resource type="FontFile" uid="uid://df06bw7a1s1u7" path="res://fonts/Montserrat-Bold.ttf" id="3_attg0"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jqwc5"]
+border_width_left = 10
+border_width_top = 10
+border_width_right = 10
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 270
+corner_radius_top_right = 270
+
+[sub_resource type="AudioStreamGenerator" id="AudioStreamGenerator_obkhd"]
+mix_rate = 22050.0
+
+[node name="Tuner" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_nftna")
+tuning_mode = 0
+
+[node name="NeedleAnchor" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 0
+
+[node name="Needle" type="Sprite2D" parent="NeedleAnchor"]
+unique_name_in_owner = true
+scale = Vector2(10, 20)
+texture = ExtResource("1_gdowb")
+centered = false
+offset = Vector2(-6, -21)
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -270.0
+offset_top = -270.0
+offset_right = 270.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_styles/panel = SubResource("StyleBoxFlat_jqwc5")
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -57.5
+offset_top = -220.0
+offset_right = 57.5
+offset_bottom = -33.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_fonts/font = ExtResource("3_attg0")
+theme_override_font_sizes/font_size = 150
+text = "A"
+horizontal_alignment = 1
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+stream = SubResource("AudioStreamGenerator_obkhd")
+autoplay = true


### PR DESCRIPTION
This tuner takes in a frequency and matches it to the closest frequency that's in tune. You can switch between chromatic, guiter and phin tuning, although I'm not 100% sure on the octaves the phin plays (I'm assuming high E is equal to guitar in this code). It's just the logic and not any useful UI, I don't want to spend time on that until we have either a design ready or working microphone pitch detection.

I added a test sweep through the entire range of frequencies we support (piano keyboard plus a few extra notes). The sweep continues for one more note than we have because that's easier to do, that's why it hangs on the highest note (G#8).