### PR TITLE
Rendering fix 1

### DIFF
--- a/autoload/debug/debug.gd
+++ b/autoload/debug/debug.gd
@@ -5,6 +5,7 @@ extends CanvasLayer
 
 
 var _is_active: bool = true
+var print_note_spawn := false
 
 
 func _ready():

--- a/project.godot
+++ b/project.godot
@@ -11,9 +11,9 @@ config_version=5
 [application]
 
 config/name="Lam-dj"
-run/main_scene="res://test/unit/test_instruments/test_piano_01/test_piano_01.tscn"
+run/main_scene="res://test/unit/test_performance_seek_single_player/test_performance_seek_piano.tscn"
 config/features=PackedStringArray("4.0", "Mobile")
-run/main_scene.web="res://test/unit/test_instruments/test_piano_01/test_piano_01.tscn"
+run/main_scene.web="res://test/unit/test_performance_seek_single_player/test_performance_seek_piano.tscn"
 
 [audio]
 

--- a/project.godot
+++ b/project.godot
@@ -11,9 +11,9 @@ config_version=5
 [application]
 
 config/name="Lam-dj"
-run/main_scene="res://test/unit/test_performance_seek_single_player/test_performance_seek_piano.tscn"
+run/main_scene="res://scenes/instrument_selection/instrument_selection.tscn"
 config/features=PackedStringArray("4.0", "Mobile")
-run/main_scene.web="res://test/unit/test_performance_seek_single_player/test_performance_seek_piano.tscn"
+run/main_scene.web="res://scenes/main.tscn"
 
 [audio]
 
@@ -76,5 +76,4 @@ media_pause_play={
 
 renderer/rendering_method="mobile"
 anti_aliasing/quality/msaa_3d=2
-anti_aliasing/quality/use_debanding=true
 mesh_lod/lod_change/threshold_pixels=0.0

--- a/project.godot
+++ b/project.godot
@@ -11,9 +11,9 @@ config_version=5
 [application]
 
 config/name="Lam-dj"
-run/main_scene="res://scenes/instrument_selection/instrument_selection.tscn"
+run/main_scene="res://test/unit/test_instruments/test_piano_01/test_piano_01.tscn"
 config/features=PackedStringArray("4.0", "Mobile")
-run/main_scene.web="res://scenes/main.tscn"
+run/main_scene.web="res://test/unit/test_instruments/test_piano_01/test_piano_01.tscn"
 
 [audio]
 
@@ -76,4 +76,5 @@ media_pause_play={
 
 renderer/rendering_method="mobile"
 anti_aliasing/quality/msaa_3d=2
+anti_aliasing/quality/use_debanding=true
 mesh_lod/lod_change/threshold_pixels=0.0

--- a/scenes/performance.gd
+++ b/scenes/performance.gd
@@ -6,6 +6,7 @@ extends Node3D
 @onready var ingame_scores_viewer = %IngameScores
 @onready var song_loader = %SongLoader
 @export var should_print_song_loading_debugs: bool = false
+@onready var vfx = %VFX
 
 var test_song_path := "res://Arlow - How Do You Know [NCS Release].mp3"
 
@@ -129,6 +130,7 @@ func sync_audiostream_remote(p_playing: bool, p_seek):
 		if p_playing:
 			audio_stream.play(p_seek)
 			if is_instance_valid(performance_instrument) and p_seek == 0:
+				# TODO : there is an issue with browser not allowing music to play unless the tab is clicked on.
 				performance_instrument.start_game(current_song)
 		else:
 			audio_stream.stream_paused = true

--- a/scenes/performance.tscn
+++ b/scenes/performance.tscn
@@ -19,6 +19,20 @@ glow_blend_mode = 1
 
 [sub_resource type="FastNoiseLite" id="FastNoiseLite_vkhm1"]
 
+[sub_resource type="BoxMesh" id="BoxMesh_wojtk"]
+size = Vector3(1, 1.5, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_dll8t"]
+blend_mode = 1
+depth_draw_mode = 2
+shading_mode = 0
+albedo_color = Color(0.207843, 0.505882, 0.615686, 1)
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_4dhpi"]
+top_radius = 0.4
+bottom_radius = 0.2
+height = 0.2
+
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_xi6so"]
 blend_mode = 1
 depth_draw_mode = 2
@@ -70,20 +84,6 @@ shader_parameter/color = Color(0.0666667, 0.215686, 0.266667, 1)
 shader_parameter/noise_texture = SubResource("NoiseTexture2D_4pjh5")
 shader_parameter/gradient_texture = SubResource("GradientTexture1D_brc8k")
 
-[sub_resource type="BoxMesh" id="BoxMesh_wojtk"]
-size = Vector3(1, 1.5, 1)
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_dll8t"]
-blend_mode = 1
-depth_draw_mode = 2
-shading_mode = 0
-albedo_color = Color(0.207843, 0.505882, 0.615686, 1)
-
-[sub_resource type="CylinderMesh" id="CylinderMesh_4dhpi"]
-top_radius = 0.4
-bottom_radius = 0.2
-height = 0.2
-
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5d8mf"]
 bg_color = Color(0, 0, 0, 0.313726)
 corner_radius_top_left = 100
@@ -122,7 +122,40 @@ noise = SubResource("FastNoiseLite_vkhm1")
 piano_position = Vector3(0, 9, 15)
 piano_rotation_degrees = Vector3(-16, 0, 0)
 
-[node name="DancingDots" type="MultiMeshInstance3D" parent="."]
+[node name="VFX" type="Node3D" parent="."]
+unique_name_in_owner = true
+
+[node name="Speaker" type="MeshInstance3D" parent="VFX"]
+transform = Transform3D(3.42274, 0.595297, 3.5959, 0, 4.93286, -0.81663, -3.64484, 0.559022, 3.37678, -24.983, 4.482, -43.744)
+mesh = SubResource("BoxMesh_wojtk")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_dll8t")
+script = ExtResource("5_5sxnp")
+
+[node name="SpeakerCone" type="MeshInstance3D" parent="VFX/Speaker"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.163811, 0.57376)
+mesh = SubResource("CylinderMesh_4dhpi")
+surface_material_override/0 = SubResource("StandardMaterial3D_dll8t")
+
+[node name="Marker3D" type="Marker3D" parent="VFX/Speaker/SpeakerCone"]
+transform = Transform3D(1, -3.72529e-08, 5.96046e-08, 2.98023e-08, -4.47035e-08, 1, -7.45058e-09, -1, -5.96046e-08, -9.53674e-07, 0.100002, -1.19209e-07)
+
+[node name="Speaker2" type="MeshInstance3D" parent="VFX"]
+transform = Transform3D(3.42274, -0.595297, -3.5959, 0, 4.93286, -0.81663, 3.64484, 0.559022, 3.37678, 36.076, 4.482, -43.744)
+mesh = SubResource("BoxMesh_wojtk")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_dll8t")
+script = ExtResource("5_5sxnp")
+
+[node name="SpeakerCone" type="MeshInstance3D" parent="VFX/Speaker2"]
+transform = Transform3D(1, 0, 1.49012e-08, 0, -5.96046e-08, -1, 0, 1, -5.21541e-08, -4.76837e-07, 0.163811, 0.57376)
+mesh = SubResource("CylinderMesh_4dhpi")
+surface_material_override/0 = SubResource("StandardMaterial3D_dll8t")
+
+[node name="Marker3D" type="Marker3D" parent="VFX/Speaker2/SpeakerCone"]
+transform = Transform3D(1, 2.23517e-08, 5.96046e-08, 0, -5.21541e-08, 1, 0, -1, -4.47035e-08, 0, 0.1, 0)
+
+[node name="DancingDots" type="MultiMeshInstance3D" parent="VFX"]
 transform = Transform3D(0.99863, -0.052336, 0, 0.052336, 0.99863, 0, 0, 0, 1, 19, -1.51263, -42)
 multimesh = SubResource("MultiMesh_em4ti")
 script = ExtResource("2_kgtlr")
@@ -131,7 +164,7 @@ noise_speed = 30.0
 noise_frequency = 3.0
 noise_strength = 3.0
 
-[node name="DancingDots2" type="MultiMeshInstance3D" parent="."]
+[node name="DancingDots2" type="MultiMeshInstance3D" parent="VFX"]
 transform = Transform3D(0.99863, 0.052336, 0, -0.052336, 0.99863, 0, 0, 0, 1, -32, 0, -42)
 multimesh = SubResource("MultiMesh_xyeju")
 script = ExtResource("2_kgtlr")
@@ -140,38 +173,11 @@ noise_speed = -30.0
 noise_frequency = 3.0
 noise_strength = 3.0
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+[node name="MeshInstance3D" type="MeshInstance3D" parent="VFX"]
 transform = Transform3D(3, 0, 0, 0, -4.37114e-08, 3, 0, -1, -1.31134e-07, 0, 0, -76.245)
 mesh = SubResource("CylinderMesh_j84wq")
+skeleton = NodePath("../..")
 surface_material_override/0 = SubResource("ShaderMaterial_kqf8v")
-
-[node name="Speaker" type="MeshInstance3D" parent="."]
-transform = Transform3D(3.42274, 0.595297, 3.5959, 0, 4.93286, -0.81663, -3.64484, 0.559022, 3.37678, -24.983, 4.482, -43.744)
-mesh = SubResource("BoxMesh_wojtk")
-surface_material_override/0 = SubResource("StandardMaterial3D_dll8t")
-script = ExtResource("5_5sxnp")
-
-[node name="SpeakerCone" type="MeshInstance3D" parent="Speaker"]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.163811, 0.57376)
-mesh = SubResource("CylinderMesh_4dhpi")
-surface_material_override/0 = SubResource("StandardMaterial3D_dll8t")
-
-[node name="Marker3D" type="Marker3D" parent="Speaker/SpeakerCone"]
-transform = Transform3D(1, -3.72529e-08, 5.96046e-08, 2.98023e-08, -4.47035e-08, 1, -7.45058e-09, -1, -5.96046e-08, -9.53674e-07, 0.100002, -1.19209e-07)
-
-[node name="Speaker2" type="MeshInstance3D" parent="."]
-transform = Transform3D(3.42274, -0.595297, -3.5959, 0, 4.93286, -0.81663, 3.64484, 0.559022, 3.37678, 36.076, 4.482, -43.744)
-mesh = SubResource("BoxMesh_wojtk")
-surface_material_override/0 = SubResource("StandardMaterial3D_dll8t")
-script = ExtResource("5_5sxnp")
-
-[node name="SpeakerCone" type="MeshInstance3D" parent="Speaker2"]
-transform = Transform3D(1, 0, 1.49012e-08, 0, -5.96046e-08, -1, 0, 1, -5.21541e-08, -4.76837e-07, 0.163811, 0.57376)
-mesh = SubResource("CylinderMesh_4dhpi")
-surface_material_override/0 = SubResource("StandardMaterial3D_dll8t")
-
-[node name="Marker3D" type="Marker3D" parent="Speaker2/SpeakerCone"]
-transform = Transform3D(1, 2.23517e-08, 5.96046e-08, 0, -5.21541e-08, 1, 0, -1, -4.47035e-08, 0, 0.1, 0)
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 

--- a/scenes/performance/instruments/instrument_notes.gd
+++ b/scenes/performance/instruments/instrument_notes.gd
@@ -80,7 +80,8 @@ func _is_missed_note(note_index: int):
 
 # Abstract, override in child class
 func spawn_note(note_data: Note, note_index: int):
-	pass
+	if Debug.print_note_spawn:
+		print("Spawning Note [idx=%d,time=%d]" % [note_index, note_data.time])
 
 
 # Abstract, override in child class

--- a/scenes/performance/speaker.gd
+++ b/scenes/performance/speaker.gd
@@ -6,8 +6,8 @@ var sound_effect_scene: PackedScene = preload("res://scenes/performance/speaker_
 func _ready():
 	# this is better than waiting for process frame.
 	await owner.ready
-	if(is_instance_valid(get_parent().performance_instrument)):
-		get_parent().performance_instrument.note_started.connect(on_note_started)
+	if(is_instance_valid(owner.performance_instrument)):
+		owner.performance_instrument.note_started.connect(on_note_started)
 
 
 func on_note_started(_note_data):

--- a/scenes/performance/speaker_sound.tscn
+++ b/scenes/performance/speaker_sound.tscn
@@ -3,16 +3,31 @@
 [ext_resource type="Script" path="res://scenes/performance/speaker_sound.gd" id="1_0m1he"]
 [ext_resource type="Shader" path="res://scenes/performance/speaker_sound.gdshader" id="1_koi0h"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_umaxm"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_70xwl"]
 render_priority = 0
 shader = ExtResource("1_koi0h")
 shader_parameter/color = Color(1, 1, 0.34, 1)
 shader_parameter/radius = 1.0
 shader_parameter/thickness = 0.01
 
-[sub_resource type="QuadMesh" id="QuadMesh_q0dx0"]
+[sub_resource type="QuadMesh" id="QuadMesh_rx11m"]
 
-[sub_resource type="Animation" id="Animation_mx752"]
+[sub_resource type="Animation" id="Animation_nejpj"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(0, 0, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_m8fs7"]
 resource_name = "grow"
 tracks/0/type = "value"
 tracks/0/imported = false
@@ -53,25 +68,10 @@ tracks/2/keys = {
 }]
 }
 
-[sub_resource type="Animation" id="Animation_wvuxs"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath(".:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector3(0, 0, 1)]
-}
-
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_42oq1"]
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_kn32k"]
 _data = {
-"RESET": SubResource("Animation_wvuxs"),
-"grow": SubResource("Animation_mx752")
+"RESET": SubResource("Animation_nejpj"),
+"grow": SubResource("Animation_m8fs7")
 }
 
 [node name="Node3D" type="Node3D"]
@@ -79,10 +79,10 @@ script = ExtResource("1_0m1he")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1)
-material_override = SubResource("ShaderMaterial_umaxm")
-mesh = SubResource("QuadMesh_q0dx0")
+material_override = SubResource("ShaderMaterial_70xwl")
+mesh = SubResource("QuadMesh_rx11m")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="MeshInstance3D"]
 libraries = {
-"": SubResource("AnimationLibrary_42oq1")
+"": SubResource("AnimationLibrary_kn32k")
 }

--- a/scenes/song_parser/chord.gd
+++ b/scenes/song_parser/chord.gd
@@ -73,6 +73,8 @@ func get_pitch_for_string(string_index: int) -> float:
 			return NoteFrequency.CHROMATIC[string_chromatic_indices[5] + fret_5]
 		_:
 			return -1.0
+	# workaround for parse error.
+	return -1.0
 
 
 func has_pitch(pitch: float) -> bool:

--- a/test/unit/test_instruments/test_piano_01/piano_01_note.gd
+++ b/test/unit/test_instruments/test_piano_01/piano_01_note.gd
@@ -1,0 +1,19 @@
+extends InstrumentNote
+
+
+func set_color(value):
+	pass
+#	$MeshInstance3D.material_override.albedo_color = value
+#	$MeshInstance3D.material_override.emission = value
+#	$DurationTail/MeshInstance3D.material_override.albedo_color = 0.5 * value
+
+
+func set_duration(value):
+	duration = value
+	$DurationTail.scale.z = value * speed
+
+
+func _ready():
+	pass
+#	$MeshInstance3D.material_override = $MeshInstance3D.material_override.duplicate()
+#	$DurationTail/MeshInstance3D.material_override = $DurationTail/MeshInstance3D.material_override.duplicate()

--- a/test/unit/test_instruments/test_piano_01/piano_01_note.tscn
+++ b/test/unit/test_instruments/test_piano_01/piano_01_note.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=6 format=3 uid="uid://bb1e1pw1rtchg"]
+
+[ext_resource type="Script" path="res://test/unit/test_instruments/test_piano_01/piano_01_note.gd" id="1_gf227"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_w8le8"]
+shading_mode = 0
+albedo_color = Color(0, 0.682353, 0.803922, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_jvrc4"]
+size = Vector3(0.6, 0.4, 0.2)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_il3f5"]
+shading_mode = 0
+albedo_color = Color(0, 0.266667, 0.313726, 1)
+
+[sub_resource type="QuadMesh" id="QuadMesh_wko5a"]
+size = Vector2(0.4, 1)
+
+[node name="PianoNote" type="Node3D"]
+script = ExtResource("1_gf227")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+material_override = SubResource("StandardMaterial3D_w8le8")
+mesh = SubResource("BoxMesh_jvrc4")
+
+[node name="DurationTail" type="Node3D" parent="."]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="DurationTail"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0.1, -0.5)
+material_override = SubResource("StandardMaterial3D_il3f5")
+mesh = SubResource("QuadMesh_wko5a")

--- a/test/unit/test_instruments/test_piano_01/test_lane_01.tres
+++ b/test/unit/test_instruments/test_piano_01/test_lane_01.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Shader" format=3 uid="uid://bv6ss5li4crtt"]
+
+[resource]
+code = "shader_type spatial;
+render_mode blend_add, unshaded, depth_draw_never;
+
+uniform vec4 color : source_color;
+uniform float brightness = 0.5;
+
+void fragment() {
+	float gradient = UV.x;
+	// An inverted parabola with the peak at (0.5, 1.0)
+	gradient = -4.0 * gradient * gradient + 4.0 * gradient;
+	gradient *= UV.y;
+	ALBEDO = brightness * color.rgb * gradient;
+}
+"

--- a/test/unit/test_instruments/test_piano_01/test_piano_01.gd
+++ b/test/unit/test_instruments/test_piano_01/test_piano_01.gd
@@ -1,0 +1,70 @@
+extends PerformanceInstrument
+
+
+const MIDDLE_C_OFFSET = 3 + 3 * 12
+const MOVEMENT_DISTANCE_THRESHOLD: float = 1.0
+
+@onready var target_position = position
+
+@export var move_speed = 0.1
+
+
+func _ready():
+	GBackend.ui_node.visible = false
+#	if not SongsConfigPreloader.is_song_preload_completed:
+#		set_process(false)
+#		print("Waiting for song configurations...")
+#		await SongsConfigPreloader.song_preload_completed
+#		print("Song configurations loaded")
+#		set_process(true)
+	
+	var keyboard_instrument = InstrumentInput.get_instrument(InstrumentInput.get_instrument_index("ComputerKeyboardInput"))
+	keyboard_instrument.octave_changed.connect(on_keyboard_octave_changed)
+	keyboard_instrument.activated.connect(on_keyboard_activated)
+	keyboard_instrument.deactivated.connect(on_keyboard_deactivated)
+	
+	if keyboard_instrument.is_active:
+		on_keyboard_activated()
+	else:
+		on_keyboard_deactivated()
+	
+	$Notes.note_spawned.connect(on_note_spawned)
+	$Notes.note_destroyed.connect(on_note_destroyed)
+	
+	var debug_note := Note.new()
+	debug_note.string = 0
+	debug_note.time = 6.0
+	
+	$Notes.spawn_note(debug_note,0)
+
+
+func on_keyboard_octave_changed(new_offset):
+	$ComputerKeyboardLabels.position.x = 7 * (new_offset - MIDDLE_C_OFFSET) / 12
+
+
+func on_keyboard_activated():
+	$ComputerKeyboardLabels.show()
+
+
+func on_keyboard_deactivated():
+	$ComputerKeyboardLabels.hide()
+
+
+func on_note_spawned():
+	update_position()
+
+
+func on_note_destroyed():
+	return
+#	update_position()
+
+
+func update_position():
+	var notes_center = $Notes.get_notes_center_x()
+	target_position.x = -notes_center
+
+
+func _process(delta):
+	if target_position.distance_to(position) >= MOVEMENT_DISTANCE_THRESHOLD:
+		var direction = (target_position - position).normalized()
+		translate(direction * move_speed * delta)

--- a/test/unit/test_instruments/test_piano_01/test_piano_01.tscn
+++ b/test/unit/test_instruments/test_piano_01/test_piano_01.tscn
@@ -1,0 +1,1293 @@
+[gd_scene load_steps=18 format=3 uid="uid://0plnc3rmegn5"]
+
+[ext_resource type="Script" path="res://test/unit/test_instruments/test_piano_01/test_piano_01.gd" id="1_uyaxf"]
+[ext_resource type="Shader" uid="uid://bv6ss5li4crtt" path="res://test/unit/test_instruments/test_piano_01/test_lane_01.tres" id="2_t5ipn"]
+[ext_resource type="Shader" path="res://scenes/performance/lane.gdshader" id="3_k6v2y"]
+[ext_resource type="PackedScene" uid="uid://beupsbquc3ecv" path="res://models/instruments/piano.glb" id="4_o18do"]
+[ext_resource type="Script" path="res://models/instruments/piano_model_data.gd" id="5_0mvkm"]
+[ext_resource type="Script" path="res://test/unit/test_instruments/test_piano_01/test_piano_01_notes.gd" id="6_cqyv7"]
+[ext_resource type="PackedScene" uid="uid://bb1e1pw1rtchg" path="res://test/unit/test_instruments/test_piano_01/piano_01_note.tscn" id="7_41k7l"]
+
+[sub_resource type="QuadMesh" id="QuadMesh_jsx2x"]
+size = Vector2(0.8, 48)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_nvaay"]
+render_priority = 0
+shader = ExtResource("2_t5ipn")
+shader_parameter/color = Color(0.207843, 0.505882, 0.615686, 1)
+shader_parameter/brightness = 0.5
+
+[sub_resource type="QuadMesh" id="QuadMesh_26rtg"]
+size = Vector2(0.7, 48)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ajkf1"]
+render_priority = 0
+shader = ExtResource("3_k6v2y")
+shader_parameter/color = Color(0.207843, 0.505882, 0.615686, 1)
+shader_parameter/brightness = 0.5
+
+[sub_resource type="QuadMesh" id="QuadMesh_agorw"]
+size = Vector2(0.6, 48)
+
+[sub_resource type="QuadMesh" id="QuadMesh_lqi4i"]
+size = Vector2(0.55, 48)
+
+[sub_resource type="QuadMesh" id="QuadMesh_4ixt8"]
+size = Vector2(1, 48)
+
+[sub_resource type="QuadMesh" id="QuadMesh_e2adn"]
+size = Vector2(0.5, 48)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_avhs0"]
+render_priority = 0
+shader = ExtResource("2_t5ipn")
+shader_parameter/color = Color(0.619608, 0.211765, 0.211765, 1)
+shader_parameter/brightness = 0.5
+
+[sub_resource type="Environment" id="Environment_6xibu"]
+background_mode = 1
+
+[node name="PerformancePiano" type="Node3D"]
+script = ExtResource("1_uyaxf")
+
+[node name="Lanes" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -23, 0, 0)
+
+[node name="WhiteLanes" type="Node3D" parent="Lanes"]
+
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0.4, 0, -24)
+mesh = SubResource("QuadMesh_jsx2x")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="MeshInstance3D4" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 1.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 2.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="MeshInstance3D7" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 3.5, 0, -24)
+mesh = SubResource("QuadMesh_agorw")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D10" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 6.475, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D11" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 7.525, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D8" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 4.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D9" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D6" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 8.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D12" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 9.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="MeshInstance3D13" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 10.5, 0, -24)
+mesh = SubResource("QuadMesh_agorw")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D14" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 13.475, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D15" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 14.525, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D16" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 11.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D17" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 12.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D18" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 15.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D19" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 16.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="MeshInstance3D20" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 17.5, 0, -24)
+mesh = SubResource("QuadMesh_agorw")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D21" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 20.475, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D22" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 21.525, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D23" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 18.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D24" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 19.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D25" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 22.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D26" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 23.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="MeshInstance3D27" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 24.5, 0, -24)
+mesh = SubResource("QuadMesh_agorw")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D28" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 27.475, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D29" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 28.525, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D30" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 25.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D31" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 26.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D32" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 29.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D33" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 30.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="MeshInstance3D34" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 31.5, 0, -24)
+mesh = SubResource("QuadMesh_agorw")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D35" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 34.475, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D36" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 35.525, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D37" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 32.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D38" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 33.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D39" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 36.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D40" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 37.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="MeshInstance3D41" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 38.5, 0, -24)
+mesh = SubResource("QuadMesh_agorw")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D42" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 41.475, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D43" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 42.525, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D44" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 39.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D45" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 40.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D46" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 43.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D47" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 44.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="MeshInstance3D48" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 45.5, 0, -24)
+mesh = SubResource("QuadMesh_agorw")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D49" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 48.475, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D50" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 49.525, 0, -24)
+mesh = SubResource("QuadMesh_lqi4i")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D51" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 46.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D52" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 47.35, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D53" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 50.65, 0, -24)
+mesh = SubResource("QuadMesh_26rtg")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_ajkf1")
+
+[node name="MeshInstance3D54" type="MeshInstance3D" parent="Lanes/WhiteLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 51.5, 0, -24)
+mesh = SubResource("QuadMesh_4ixt8")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_nvaay")
+
+[node name="BlackLanes" type="Node3D" parent="Lanes"]
+
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 1.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D4" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 2.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D5" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 4.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D6" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D7" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 7, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D8" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 8.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D9" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 9.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D10" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 11.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D11" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 12.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D12" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 14, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D13" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 15.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D14" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 16.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D15" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 18.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D16" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 19.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D17" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 21, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D18" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 22.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D19" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 23.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D20" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 25.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D21" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 26.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D22" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 28, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D23" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 29.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D24" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 30.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D25" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 32.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D26" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 33.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D27" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 35, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D28" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 36.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D29" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 37.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D30" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 39.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D31" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 40.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D32" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 42, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D33" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 43.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D34" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 44.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D35" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 46.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D36" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 47.95, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D37" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 49, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="MeshInstance3D38" type="MeshInstance3D" parent="Lanes/BlackLanes"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 50.05, 0, -24)
+mesh = SubResource("QuadMesh_e2adn")
+skeleton = NodePath("../../../..")
+surface_material_override/0 = SubResource("ShaderMaterial_avhs0")
+
+[node name="piano" parent="." instance=ExtResource("4_o18do")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -23, 0, 0)
+script = ExtResource("5_0mvkm")
+key_nodes = [NodePath("key_a_0"), NodePath("key_a_sharp_0"), NodePath("key_b_0"), NodePath("key_c_1"), NodePath("key_c_sharp_1"), NodePath("key_d_1"), NodePath("key_d_sharp_1"), NodePath("key_e_1"), NodePath("key_f_1"), NodePath("key_f_sharp_1"), NodePath("key_g_1"), NodePath("key_g_sharp_1"), NodePath("key_a_1"), NodePath("key_a_sharp_1"), NodePath("key_b_1"), NodePath("key_c_2"), NodePath("key_c_sharp_2"), NodePath("key_d_2"), NodePath("key_d_sharp_2"), NodePath("key_e_2"), NodePath("key_f_2"), NodePath("key_f_sharp_2"), NodePath("key_g_2"), NodePath("key_g_sharp_2"), NodePath("key_a_2"), NodePath("key_a_sharp_2"), NodePath("key_b_2"), NodePath("key_c_3"), NodePath("key_c_sharp_3"), NodePath("key_d_3"), NodePath("key_d_sharp_3"), NodePath("key_e_3"), NodePath("key_f_3"), NodePath("key_f_sharp_3"), NodePath("key_g_3"), NodePath("key_g_sharp_3"), NodePath("key_a_3"), NodePath("key_a_sharp_3"), NodePath("key_b_3"), NodePath("key_c_4"), NodePath("key_c_sharp_4"), NodePath("key_d_4"), NodePath("key_d_sharp_4"), NodePath("key_e_4"), NodePath("key_f_4"), NodePath("key_f_sharp_4"), NodePath("key_g_4"), NodePath("key_g_sharp_4"), NodePath("key_a_4"), NodePath("key_a_sharp_4"), NodePath("key_b_4"), NodePath("key_c_5"), NodePath("key_c_sharp_5"), NodePath("key_d_5"), NodePath("key_d_sharp_5"), NodePath("key_e_5"), NodePath("key_f_5"), NodePath("key_f_sharp_5"), NodePath("key_g_5"), NodePath("key_g_sharp_5"), NodePath("key_a_5"), NodePath("key_a_sharp_5"), NodePath("key_b_5"), NodePath("key_c_6"), NodePath("key_c_sharp_6"), NodePath("key_d_6"), NodePath("key_d_sharp_6"), NodePath("key_e_6"), NodePath("key_f_6"), NodePath("key_f_sharp_6"), NodePath("key_g_6"), NodePath("key_g_sharp_6"), NodePath("key_a_6"), NodePath("key_a_sharp_6"), NodePath("key_b_6"), NodePath("key_c_7"), NodePath("key_c_sharp_7"), NodePath("key_d_7"), NodePath("key_e_sharp_7"), NodePath("key_e_7"), NodePath("key_f_7"), NodePath("key_F_sharp_7"), NodePath("key_g_7"), NodePath("key_g_sharp_7"), NodePath("key_a_7"), NodePath("key_a_sharp_7"), NodePath("key_b_7"), NodePath("key_c_8")]
+
+[node name="key_a_sharp_0" parent="piano" index="0"]
+visible = false
+
+[node name="key_a_0" parent="piano" index="1"]
+visible = false
+
+[node name="key_b_0" parent="piano" index="2"]
+visible = false
+
+[node name="key_c_1" parent="piano" index="3"]
+visible = false
+
+[node name="key_c_sharp_1" parent="piano" index="4"]
+visible = false
+
+[node name="key_d_sharp_1" parent="piano" index="5"]
+visible = false
+
+[node name="key_a_sharp_1" parent="piano" index="6"]
+visible = false
+
+[node name="key_f_sharp_1" parent="piano" index="7"]
+visible = false
+
+[node name="key_g_sharp_1" parent="piano" index="8"]
+visible = false
+
+[node name="key_d_1" parent="piano" index="9"]
+visible = false
+
+[node name="key_e_1" parent="piano" index="10"]
+visible = false
+
+[node name="key_f_1" parent="piano" index="11"]
+visible = false
+
+[node name="key_g_1" parent="piano" index="12"]
+visible = false
+
+[node name="key_a_1" parent="piano" index="13"]
+visible = false
+
+[node name="key_b_1" parent="piano" index="14"]
+visible = false
+
+[node name="key_c_2" parent="piano" index="15"]
+visible = false
+
+[node name="key_c_sharp_2" parent="piano" index="16"]
+visible = false
+
+[node name="key_d_sharp_2" parent="piano" index="17"]
+visible = false
+
+[node name="key_a_sharp_2" parent="piano" index="18"]
+visible = false
+
+[node name="key_f_sharp_2" parent="piano" index="19"]
+visible = false
+
+[node name="key_g_sharp_2" parent="piano" index="20"]
+visible = false
+
+[node name="key_d_2" parent="piano" index="21"]
+visible = false
+
+[node name="key_e_2" parent="piano" index="22"]
+visible = false
+
+[node name="key_f_2" parent="piano" index="23"]
+visible = false
+
+[node name="key_g_2" parent="piano" index="24"]
+visible = false
+
+[node name="key_a_2" parent="piano" index="25"]
+visible = false
+
+[node name="key_b_2" parent="piano" index="26"]
+visible = false
+
+[node name="key_c_3" parent="piano" index="27"]
+visible = false
+
+[node name="key_c_sharp_3" parent="piano" index="28"]
+visible = false
+
+[node name="key_d_sharp_3" parent="piano" index="29"]
+visible = false
+
+[node name="key_a_sharp_3" parent="piano" index="30"]
+visible = false
+
+[node name="key_f_sharp_3" parent="piano" index="31"]
+visible = false
+
+[node name="key_g_sharp_3" parent="piano" index="32"]
+visible = false
+
+[node name="key_d_3" parent="piano" index="33"]
+visible = false
+
+[node name="key_e_3" parent="piano" index="34"]
+visible = false
+
+[node name="key_f_3" parent="piano" index="35"]
+visible = false
+
+[node name="key_g_3" parent="piano" index="36"]
+visible = false
+
+[node name="key_a_3" parent="piano" index="37"]
+visible = false
+
+[node name="key_b_3" parent="piano" index="38"]
+visible = false
+
+[node name="key_c_4" parent="piano" index="39"]
+visible = false
+
+[node name="key_c_sharp_4" parent="piano" index="40"]
+visible = false
+
+[node name="key_d_sharp_4" parent="piano" index="41"]
+visible = false
+
+[node name="key_a_sharp_4" parent="piano" index="42"]
+visible = false
+
+[node name="key_f_sharp_4" parent="piano" index="43"]
+visible = false
+
+[node name="key_g_sharp_4" parent="piano" index="44"]
+visible = false
+
+[node name="key_d_4" parent="piano" index="45"]
+visible = false
+
+[node name="key_e_4" parent="piano" index="46"]
+visible = false
+
+[node name="key_f_4" parent="piano" index="47"]
+visible = false
+
+[node name="key_g_4" parent="piano" index="48"]
+visible = false
+
+[node name="key_a_4" parent="piano" index="49"]
+visible = false
+
+[node name="key_b_4" parent="piano" index="50"]
+visible = false
+
+[node name="key_c_5" parent="piano" index="51"]
+visible = false
+
+[node name="key_c_sharp_5" parent="piano" index="52"]
+visible = false
+
+[node name="key_d_sharp_5" parent="piano" index="53"]
+visible = false
+
+[node name="key_a_sharp_5" parent="piano" index="54"]
+visible = false
+
+[node name="key_f_sharp_5" parent="piano" index="55"]
+visible = false
+
+[node name="key_g_sharp_5" parent="piano" index="56"]
+visible = false
+
+[node name="key_d_5" parent="piano" index="57"]
+visible = false
+
+[node name="key_e_5" parent="piano" index="58"]
+visible = false
+
+[node name="key_f_5" parent="piano" index="59"]
+visible = false
+
+[node name="key_g_5" parent="piano" index="60"]
+visible = false
+
+[node name="key_a_5" parent="piano" index="61"]
+visible = false
+
+[node name="key_b_5" parent="piano" index="62"]
+visible = false
+
+[node name="key_c_6" parent="piano" index="63"]
+visible = false
+
+[node name="key_c_sharp_6" parent="piano" index="64"]
+visible = false
+
+[node name="key_d_sharp_6" parent="piano" index="65"]
+visible = false
+
+[node name="key_a_sharp_6" parent="piano" index="66"]
+visible = false
+
+[node name="key_f_sharp_6" parent="piano" index="67"]
+visible = false
+
+[node name="key_g_sharp_6" parent="piano" index="68"]
+visible = false
+
+[node name="key_d_6" parent="piano" index="69"]
+visible = false
+
+[node name="key_e_6" parent="piano" index="70"]
+visible = false
+
+[node name="key_f_6" parent="piano" index="71"]
+visible = false
+
+[node name="key_g_6" parent="piano" index="72"]
+visible = false
+
+[node name="key_a_6" parent="piano" index="73"]
+visible = false
+
+[node name="key_b_6" parent="piano" index="74"]
+visible = false
+
+[node name="key_c_7" parent="piano" index="75"]
+visible = false
+
+[node name="key_c_sharp_7" parent="piano" index="76"]
+visible = false
+
+[node name="key_e_sharp_7" parent="piano" index="77"]
+visible = false
+
+[node name="key_a_sharp_7" parent="piano" index="78"]
+visible = false
+
+[node name="key_F_sharp_7" parent="piano" index="79"]
+visible = false
+
+[node name="key_g_sharp_7" parent="piano" index="80"]
+visible = false
+
+[node name="key_d_7" parent="piano" index="81"]
+visible = false
+
+[node name="key_e_7" parent="piano" index="82"]
+visible = false
+
+[node name="key_f_7" parent="piano" index="83"]
+visible = false
+
+[node name="key_g_7" parent="piano" index="84"]
+visible = false
+
+[node name="key_a_7" parent="piano" index="85"]
+visible = false
+
+[node name="key_b_7" parent="piano" index="86"]
+visible = false
+
+[node name="key_c_8" parent="piano" index="87"]
+visible = false
+
+[node name="Notes" type="Node3D" parent="."]
+script = ExtResource("6_cqyv7")
+note_scene = ExtResource("7_41k7l")
+note_speed = 3.0
+
+[node name="SpawnPositions" type="Node3D" parent="."]
+
+[node name="A0" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -22.6, 0, 0)
+
+[node name="ASharp0" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -21.95, 0, 0)
+
+[node name="B0" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -21.35, 0, 0)
+
+[node name="C1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20.65, 0, 0)
+
+[node name="CSharp1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -20.05, 0, 0)
+
+[node name="D1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -19.5, 0, 0)
+
+[node name="DSharp1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -18.95, 0, 0)
+
+[node name="E1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -18.35, 0, 0)
+
+[node name="F1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -17.65, 0, 0)
+
+[node name="FSharp1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -17.05, 0, 0)
+
+[node name="G1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -16.525, 0, 0)
+
+[node name="GSharp1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -16, 0, 0)
+
+[node name="A1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -15.475, 0, 0)
+
+[node name="ASharp1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -14.95, 0, 0)
+
+[node name="B1" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -14.35, 0, 0)
+
+[node name="C2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -13.65, 0, 0)
+
+[node name="CSharp2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -13.05, 0, 0)
+
+[node name="D2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.5, 0, 0)
+
+[node name="DSharp2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -11.95, 0, 0)
+
+[node name="E2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -11.35, 0, 0)
+
+[node name="F2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -10.65, 0, 0)
+
+[node name="FSharp2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -10.05, 0, 0)
+
+[node name="G2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -9.525, 0, 0)
+
+[node name="GSharp2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -9, 0, 0)
+
+[node name="A2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8.475, 0, 0)
+
+[node name="ASharp2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.95, 0, 0)
+
+[node name="B2" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7.35, 0, 0)
+
+[node name="C3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6.65, 0, 0)
+
+[node name="CSharp3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6.05, 0, 0)
+
+[node name="D3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.5, 0, 0)
+
+[node name="DSharp3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.95, 0, 0)
+
+[node name="E3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.35, 0, 0)
+
+[node name="F3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.65, 0, 0)
+
+[node name="FSharp3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.05, 0, 0)
+
+[node name="G3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.525, 0, 0)
+
+[node name="GSharp3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, 0)
+
+[node name="A3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.475, 0, 0)
+
+[node name="ASharp3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.95, 0, 0)
+
+[node name="B3" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.35, 0, 0)
+
+[node name="C4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.35, 0, 0)
+
+[node name="CSharp4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.950001, 0, 0)
+
+[node name="D4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.5, 0, 0)
+
+[node name="DSharp4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.05, 0, 0)
+
+[node name="E4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.65, 0, 0)
+
+[node name="F4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.35, 0, 0)
+
+[node name="FSharp4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.95, 0, 0)
+
+[node name="G4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.475, 0, 0)
+
+[node name="GSharp4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 0, 0)
+
+[node name="A4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.525, 0, 0)
+
+[node name="ASharp4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.05, 0, 0)
+
+[node name="B4" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.65, 0, 0)
+
+[node name="C5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.35, 0, 0)
+
+[node name="CSharp5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.95, 0, 0)
+
+[node name="D5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.5, 0, 0)
+
+[node name="DSharp5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9.05, 0, 0)
+
+[node name="E5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9.65, 0, 0)
+
+[node name="F5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 10.35, 0, 0)
+
+[node name="FSharp5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 10.95, 0, 0)
+
+[node name="G5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 11.475, 0, 0)
+
+[node name="GSharp5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12, 0, 0)
+
+[node name="A5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.525, 0, 0)
+
+[node name="ASharp5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13.05, 0, 0)
+
+[node name="B5" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 13.65, 0, 0)
+
+[node name="C6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 14.35, 0, 0)
+
+[node name="CSharp6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 14.95, 0, 0)
+
+[node name="D6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15.5, 0, 0)
+
+[node name="DSharp6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 16.05, 0, 0)
+
+[node name="E6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 16.65, 0, 0)
+
+[node name="F6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 17.35, 0, 0)
+
+[node name="FSharp6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 17.95, 0, 0)
+
+[node name="G6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 18.475, 0, 0)
+
+[node name="GSharp6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 19, 0, 0)
+
+[node name="A6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 19.525, 0, 0)
+
+[node name="ASharp6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20.05, 0, 0)
+
+[node name="B6" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20.65, 0, 0)
+
+[node name="C7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 21.35, 0, 0)
+
+[node name="CSharp7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 21.95, 0, 0)
+
+[node name="D7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 22.5, 0, 0)
+
+[node name="DSharp7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 23.05, 0, 0)
+
+[node name="E7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 23.65, 0, 0)
+
+[node name="F7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 24.35, 0, 0)
+
+[node name="FSharp7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 24.95, 0, 0)
+
+[node name="G7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 25.475, 0, 0)
+
+[node name="GSharp7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 26, 0, 0)
+
+[node name="A7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 26.525, 0, 0)
+
+[node name="ASharp7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 27.05, 0, 0)
+
+[node name="B7" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 27.65, 0, 0)
+
+[node name="C8" type="Marker3D" parent="SpawnPositions"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 28.5, 0, 0)
+
+[node name="ComputerKeyboardLabels" type="Node3D" parent="."]
+
+[node name="A" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "A"
+font_size = 150
+
+[node name="W" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0.95, 0.3, 3)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+text = "W
+"
+font_size = 150
+outline_size = 44
+
+[node name="S" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 1.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "S"
+font_size = 150
+
+[node name="E" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 2.04999, 0.3, 3)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+text = "E"
+font_size = 150
+outline_size = 44
+
+[node name="D" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 2.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "D"
+font_size = 150
+
+[node name="F" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 3.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "F"
+font_size = 150
+
+[node name="T" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 3.95, 0.3, 3)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+text = "T
+"
+font_size = 150
+outline_size = 44
+
+[node name="G" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 4.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "G"
+font_size = 150
+
+[node name="Y" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5, 0.3, 3)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+text = "Y
+"
+font_size = 150
+outline_size = 44
+
+[node name="U" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 6.05, 0.3, 3)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+text = "U
+"
+font_size = 150
+outline_size = 44
+
+[node name="J" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 6.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "J"
+font_size = 150
+
+[node name="K" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 7.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "K"
+font_size = 150
+
+[node name="H" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "H"
+font_size = 150
+
+[node name="O" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 7.95, 0.3, 3)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+text = "O"
+font_size = 150
+outline_size = 44
+
+[node name="L" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 8.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = "L"
+font_size = 150
+
+[node name="P" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 9.05, 0.3, 3)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+text = "P"
+font_size = 150
+outline_size = 44
+
+[node name=";" type="Label3D" parent="ComputerKeyboardLabels"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 9.5, 0.1, 5)
+sorting_offset = 1.0
+alpha_cut = 1
+render_priority = 1
+modulate = Color(0, 0, 0, 1)
+text = ";"
+font_size = 150
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.915136, 0.403146, 0, -0.403146, 0.915136, 0, 12.5275, 9.31301)
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_6xibu")
+
+[editable path="piano"]

--- a/test/unit/test_instruments/test_piano_01/test_piano_01_notes.gd
+++ b/test/unit/test_instruments/test_piano_01/test_piano_01_notes.gd
@@ -1,0 +1,67 @@
+extends InstrumentNotes
+
+
+signal note_spawned()
+signal note_destroyed()
+
+
+var last_center: float = 0.0
+
+
+func spawn_note(note_data: Note, note_index: int):
+	super.spawn_note(note_data, note_index)
+	
+	var note = note_scene.instantiate()
+	note.speed = note_speed
+	add_child(note)
+	
+	var position_index: int = NoteFrequency.CHROMATIC.find(note_data.get_pitch())
+	note.position = $"../SpawnPositions".get_child(position_index).position
+	
+	note.position.z = -note_speed * (note_data.time - time)
+	
+	note.color = Color.from_string("#35819d", Color.LIGHT_SKY_BLUE)
+	note.duration = note_data.sustain
+	note.index = note_index
+	
+	# Signals
+	note.tree_exited.connect(on_note_destroyed)
+	note_spawned.emit()
+
+
+func spawn_chord(chord_data: Chord, note_index: int):
+	super.spawn_chord(chord_data, note_index)
+	
+	for pitch in chord_data.get_pitches():
+		var note = note_scene.instantiate()
+		note.speed = note_speed
+		add_child(note)
+		
+		var position_index: int = NoteFrequency.CHROMATIC.find(pitch)
+		note.position = $"../SpawnPositions".get_child(position_index).position
+		
+		note.position.z = -note_speed * (chord_data.time - time)
+		
+		note.color = Color.from_string("#35819d", Color.LIGHT_SKY_BLUE)
+		note.duration = chord_data.sustain
+		note.index = note_index
+		
+		# Signals
+		note.tree_exited.connect(on_note_destroyed)
+		note_spawned.emit()
+
+
+func get_notes_center_x():
+	if get_child_count() == 0:
+		return last_center
+	
+	var sum := 0.0
+	for note in get_children():
+		sum += note.position.x
+	
+	last_center = sum / get_child_count()
+	return last_center
+
+
+func on_note_destroyed():
+	note_destroyed.emit()

--- a/test/unit/test_performance_seek_single_player/test_performance_seek_piano.tscn
+++ b/test/unit/test_performance_seek_single_player/test_performance_seek_piano.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://ddylmpf8nq3os"]
+
+[ext_resource type="PackedScene" uid="uid://qsxmg8k0biw2" path="res://test/unit/test_performance_seek_single_player/test_performance_seek_single_player.tscn" id="1_8tkrv"]
+
+[node name="test_performance_seek_single_player" instance=ExtResource("1_8tkrv")]
+instrument = 0

--- a/test/unit/test_performance_seek_single_player/test_performance_seek_single_player.gd
+++ b/test/unit/test_performance_seek_single_player/test_performance_seek_single_player.gd
@@ -33,9 +33,12 @@ const PERFORMANCE_SCENE := preload("res://scenes/performance.tscn")
 	SongIds[Songs.THE_DARK_SIDE_OF_THE_MOON]: 0.0
 }
 
+@export var vfx := false
+
 var performance_node: Node
 
 func _ready():
+	Debug.print_note_spawn = true
 	GBackend.ui_node.visible = false
 	SessionVariables.instrument = Instrument_ids[instrument]
 	if not SongsConfigPreloader.is_song_preload_completed:
@@ -45,6 +48,7 @@ func _ready():
 	
 	performance_node = PERFORMANCE_SCENE.instantiate()
 	add_child(performance_node)
+	performance_node.vfx.visible = vfx
 	
 	while(not performance_node.is_music_playing()):
 		await get_tree().process_frame
@@ -52,3 +56,4 @@ func _ready():
 	var initial_seek_value: float = initial_seek[SongIds[current_song]]
 	performance_node.audio_stream.seek(initial_seek_value)
 	performance_node.performance_instrument.notes.time = initial_seek_value
+	


### PR DESCRIPTION
A workaround was added to fix the script parse error in the release build of Godot.
The issue happens when you have a function with an explicit return type but use a match case's default case ```_:``` to ensure that all paths return.
Godot doesn't seem to recognize that at the moment so an extra return statement is needed at the end of the function.
A piano rendering test scene was also added. The previous performance seeking test scene now can disable VFX as well.

**Suggestion :**
From now on we should add variables to the Debug singleton that instruct specific nodes on how to behave. Then in unit test scenes's ready functions we can adjust these variables to get the desired behavior. 
This might not be the most elegant solution but it's easy to implement and use.