### PR TITLE
Allow host page to provide game login credentials in Web builds

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,7 +13,7 @@ config_version=5
 config/name="Lam-dj"
 run/main_scene="res://scenes/instrument_selection/instrument_selection.tscn"
 config/features=PackedStringArray("4.0", "Mobile")
-run/main_scene.web="res://scenes/main.tscn"
+run/main_scene.web="res://scenes/instrument_selection/instrument_selection.tscn"
 
 [audio]
 

--- a/scenes/left_bar/left_bar.gd
+++ b/scenes/left_bar/left_bar.gd
@@ -2,6 +2,8 @@
 
 extends PanelContainer
 
+var _js_enabled = Engine.has_singleton("JavaScriptBridge") && OS.get_name() == 'Web'
+
 func _ready():
 	pass
 
@@ -9,4 +11,7 @@ func _process(delta):
 	pass
 
 func _on_LoginBtn_pressed() -> void:
-	GDialogs.open_single(GLoginDialog)
+	if _js_enabled:
+		GBackend.open_js_login_dialog()
+	else:
+		GDialogs.open_single(GLoginDialog)


### PR DESCRIPTION
This also hooks up the login button on the left toolbar to show a JS/HTML dialog instead of the in-game Login dialog.

JS/HTML dialogs allow users to use auto-fill and password managers in the browser.