### PR TITLE
Use in-browser login/register dialogs in web build

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,7 +13,7 @@ config_version=5
 config/name="Lam-dj"
 run/main_scene="res://scenes/instrument_selection/instrument_selection.tscn"
 config/features=PackedStringArray("4.0", "Mobile")
-run/main_scene.web="res://scenes/main.tscn"
+run/main_scene.web="res://scenes/instrument_selection/instrument_selection.tscn"
 
 [audio]
 

--- a/scenes/left_bar/left_bar.gd
+++ b/scenes/left_bar/left_bar.gd
@@ -19,7 +19,10 @@ func _on_logout_button_pressed():
 		current_scene.go_back()
 	else:
 		await GBackend.logout()
-		Dialogs.login_dialog.open()
+		if (GBackend.is_js_enabled):
+			GBackend.open_js_login_dialog()
+		else:
+			Dialogs.login_dialog.open()
 
 
 func request_finish() -> bool:


### PR DESCRIPTION
This allows the host page to provide game login credentials in web builds.

Also hooks up the login button on the left toolbar to show a JS/HTML dialog instead of the in-game Login dialog.

JS/HTML dialogs allow users to use auto-fill and password managers in the browser.